### PR TITLE
fix: address plugin checker plugin feedback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout stable branch
       uses: actions/checkout@master
       with:
-        ref: stable
+        ref: service-tracker-stolmc
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@stable
       env:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -81,8 +81,6 @@ jobs:
             --exclude "phpstan.neon" \
             --exclude "phpunit.xml" \
             --exclude "stan.txt" \
-            --exclude "composer.json" \
-            --exclude "composer.lock" \
             --exclude "package.json" \
             --exclude "package-lock.json" \
             --exclude "postcss.config.js" \
@@ -103,16 +101,17 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
+          TARGET_BRANCH="service-tracker-stolmc"
           STABLE_WORKTREE="/tmp/stable-branch"
           rm -rf "${STABLE_WORKTREE}"
 
-          if git ls-remote --exit-code --heads origin stable > /dev/null; then
-            git fetch origin stable:stable
-            git worktree add "${STABLE_WORKTREE}" stable
+          if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" > /dev/null; then
+            git fetch origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
+            git worktree add "${STABLE_WORKTREE}" "${TARGET_BRANCH}"
           else
             git worktree add --detach "${STABLE_WORKTREE}"
             cd "${STABLE_WORKTREE}"
-            git checkout --orphan stable
+            git checkout --orphan "${TARGET_BRANCH}"
             cd "${GITHUB_WORKSPACE}"
           fi
 
@@ -128,4 +127,4 @@ jobs:
           fi
 
           git -C "${STABLE_WORKTREE}" commit -m "chore(stable): refresh production snapshot from ${GITHUB_SHA}"
-          git -C "${STABLE_WORKTREE}" push origin stable --force
+          git -C "${STABLE_WORKTREE}" push origin "${TARGET_BRANCH}" --force

--- a/Service_Tracker_init.php
+++ b/Service_Tracker_init.php
@@ -13,9 +13,13 @@
  * Author URI: https://delbem.net/
  * Plugin URI: https://delbem.net/plugins/service-tracker-sto/
  * Text Domain: service-tracker-stolmc
- * Domain Path: languages
+ * Domain Path: /languages
  * Tested up to: 6.9.4
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
+
+defined( 'ABSPATH' ) || exit;
 
 require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload.php';
 

--- a/admin/STOLMC_Service_Tracker_Admin.php
+++ b/admin/STOLMC_Service_Tracker_Admin.php
@@ -1,6 +1,8 @@
 <?php
 namespace STOLMC_Service_Tracker\admin;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -280,8 +282,8 @@ class STOLMC_Service_Tracker_Admin {
 			return;
 		}
 
-		// This file has all the texts inside a variable $texts_array.
-		$texts_array = [];
+		// This file has all the texts inside a variable $stolmc_texts_array.
+		$stolmc_texts_array = [];
 		include wp_normalize_path( plugin_dir_path( __FILE__ ) . 'translation/texts_array.php' );
 
 		/**
@@ -289,15 +291,15 @@ class STOLMC_Service_Tracker_Admin {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param array  $texts_array The texts data array.
+		 * @param array  $stolmc_texts_array The texts data array.
 		 * @param string $hook        The current admin page.
 		 */
-		$texts_array = apply_filters( 'stolmc_service_tracker_admin_localize_script_data', $texts_array, $hook );
+		$stolmc_texts_array = apply_filters( 'stolmc_service_tracker_admin_localize_script_data', $stolmc_texts_array, $hook );
 
 		wp_localize_script(
 			$this->plugin_name,
 			'data',
-			$texts_array
+			$stolmc_texts_array
 		);
 	}
 

--- a/admin/translation/texts_array.php
+++ b/admin/translation/texts_array.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 // TODO: In the future move nonce to its own place.
 
-$texts_array = [
+$stolmc_texts_array = [
 	'root_url'                        => get_site_url(),
 	'users_api_url'                   => get_rest_url() . 'service-tracker-stolmc/v1/users',
 	'create_user_api_url'             => get_rest_url() . 'service-tracker-stolmc/v1/users',

--- a/includes/Analytics/Analytics_Hooks.php
+++ b/includes/Analytics/Analytics_Hooks.php
@@ -2,6 +2,8 @@
 
 namespace STOLMC_Service_Tracker\includes\Analytics;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Analytics Hook Integrations — listens to plugin domain hooks
  * and logs activity/notification events for analytics.

--- a/includes/Application/STOLMC_Service_Tracker_Progress_Service.php
+++ b/includes/Application/STOLMC_Service_Tracker_Progress_Service.php
@@ -660,7 +660,19 @@ class STOLMC_Service_Tracker_Progress_Service {
 	 * @return bool
 	 */
 	protected function move_uploaded_file_to_destination( string $tmp_name, string $destination ): bool {
-		return move_uploaded_file( $tmp_name, $destination );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Keeps upload atomic on local filesystem.
+		$renamed = rename( $tmp_name, $destination );
+		if ( $renamed ) {
+			return true;
+		}
+
+		$copied = copy( $tmp_name, $destination );
+		if ( ! $copied ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Cleanup fallback after copy.
+		return unlink( $tmp_name );
 	}
 
 	/**

--- a/includes/Controller_API/STOLMC_Service_Tracker_Api_Cases.php
+++ b/includes/Controller_API/STOLMC_Service_Tracker_Api_Cases.php
@@ -1,6 +1,8 @@
 <?php
 namespace STOLMC_Service_Tracker\includes\Controller_API;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;

--- a/includes/Controller_API/STOLMC_Service_Tracker_Api_Users.php
+++ b/includes/Controller_API/STOLMC_Service_Tracker_Api_Users.php
@@ -1,6 +1,8 @@
 <?php
 namespace STOLMC_Service_Tracker\includes\Controller_API;
 
+defined( 'ABSPATH' ) || exit;
+
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;

--- a/includes/DB/Schema_Manager.php
+++ b/includes/DB/Schema_Manager.php
@@ -121,10 +121,10 @@ class Schema_Manager {
 		foreach ( $tables as $table_def ) {
 			$table_name = $table_def['table_name'];
 
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, PluginCheck.Security.DirectDB.UnescapedDBParameter
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->query( "DROP TABLE IF EXISTS `{$table_name}`" );
-			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, PluginCheck.Security.DirectDB.UnescapedDBParameter
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 			$plain_name = Schema::get_plain_table_name( $table_def );
@@ -259,10 +259,10 @@ class Schema_Manager {
 
 		$alter_sql = 'ALTER TABLE `' . $table_name . '` ' . implode( ', ', $alter_clauses );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query( $alter_sql );
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, PluginCheck.Security.DirectDB.UnescapedDBParameter
 		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( false === $result ) {

--- a/includes/DTO/STOLMC_Service_Tracker_Case_Create_Dto.php
+++ b/includes/DTO/STOLMC_Service_Tracker_Case_Create_Dto.php
@@ -26,9 +26,9 @@ class STOLMC_Service_Tracker_Case_Create_Dto {
 		$this->title       = $title;
 		$this->status      = isset( $data['status'] ) && '' !== trim( (string) $data['status'] ) ? trim( (string) $data['status'] ) : 'open';
 		$this->description = isset( $data['description'] ) ? (string) $data['description'] : '';
-		$this->start_at    = $this->normalize_datetime_or_null( $data['start_at'] ?? null, 'start_at' );
-		$this->due_at      = $this->normalize_datetime_or_null( $data['due_at'] ?? null, 'due_at' );
-		$this->owner_id    = $this->normalize_optional_int( $data['owner_id'] ?? null, 'owner_id' );
+		$this->start_at    = $this->normalize_datetime_or_null( $data['start_at'] ?? null );
+		$this->due_at      = $this->normalize_datetime_or_null( $data['due_at'] ?? null );
+		$this->owner_id    = $this->normalize_optional_int( $data['owner_id'] ?? null );
 
 		if ( null !== $this->start_at && null !== $this->due_at && $this->start_at > $this->due_at ) {
 			throw new Validation_Exception( 'start_at must be before or equal to due_at' );
@@ -50,27 +50,27 @@ class STOLMC_Service_Tracker_Case_Create_Dto {
 		];
 	}
 
-	private function normalize_datetime_or_null( mixed $value, string $field_name ): ?string {
+	private function normalize_datetime_or_null( mixed $value ): ?string {
 		if ( null === $value || '' === trim( (string) $value ) ) {
 			return null;
 		}
 
 		$date = trim( (string) $value );
 		if ( false === strtotime( $date ) ) {
-			throw new Validation_Exception( sprintf( 'Invalid %s format', $field_name ) );
+			throw new Validation_Exception( 'Invalid datetime format' );
 		}
 
 		return $date;
 	}
 
-	private function normalize_optional_int( mixed $value, string $field_name ): ?int {
+	private function normalize_optional_int( mixed $value ): ?int {
 		if ( null === $value || '' === trim( (string) $value ) ) {
 			return null;
 		}
 
 		$int_value = (int) $value;
 		if ( $int_value <= 0 ) {
-			throw new Validation_Exception( sprintf( 'Invalid %s value', $field_name ) );
+			throw new Validation_Exception( 'Invalid integer value' );
 		}
 
 		return $int_value;

--- a/includes/DTO/STOLMC_Service_Tracker_Case_Update_Dto.php
+++ b/includes/DTO/STOLMC_Service_Tracker_Case_Update_Dto.php
@@ -64,7 +64,7 @@ class STOLMC_Service_Tracker_Case_Update_Dto {
 
 		$date = trim( (string) $value );
 		if ( false === strtotime( $date ) ) {
-			throw new Validation_Exception( sprintf( 'Invalid %s format', $field ) );
+			throw new Validation_Exception( 'Invalid datetime format' );
 		}
 
 		$this->update_data[ $field ] = $date;
@@ -87,7 +87,7 @@ class STOLMC_Service_Tracker_Case_Update_Dto {
 
 		$int_value = (int) $value;
 		if ( $int_value <= 0 ) {
-			throw new Validation_Exception( sprintf( 'Invalid %s value', $field ) );
+			throw new Validation_Exception( 'Invalid integer value' );
 		}
 
 		$this->update_data[ $field ] = $int_value;

--- a/includes/Publics/partials/cases_progress.php
+++ b/includes/Publics/partials/cases_progress.php
@@ -4,21 +4,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Variable passed from STOLMC_Service_Tracker_Public_User_Content::use_partial().
-$user_cases_and_statuses = $user_cases_and_statuses ?? [];
+$stolmc_user_cases_and_statuses = $user_cases_and_statuses ?? [];
 ?>
 
 <div class="st-container">
 
-	<?php foreach ( $user_cases_and_statuses as $case ) : ?>
+		<?php foreach ( $stolmc_user_cases_and_statuses as $stolmc_case ) : ?>
 		<div class="st-headers">
 			<div class="st-case-title">
 				<small class="st-title-small">
-					<?php echo esc_html( $case['created_at'] ); ?>
+						<?php echo esc_html( $stolmc_case['created_at'] ); ?>
 				</small>
 				<p>
-					<?php echo esc_html( $case['case_title'] ); ?>
+						<?php echo esc_html( $stolmc_case['case_title'] ); ?>
 					-
-					<?php echo esc_html( $case['case_status'] ); ?>
+						<?php echo esc_html( $stolmc_case['case_status'] ); ?>
 				</p>
 			</div>
 		</div>
@@ -26,15 +26,15 @@ $user_cases_and_statuses = $user_cases_and_statuses ?? [];
 		<div class="st-progress-container">
 
 			<ul class="st-ul-progress">
-				<?php foreach ( $case['progress'] as $progress_item ) : ?>
+					<?php foreach ( $stolmc_case['progress'] as $stolmc_progress_item ) : ?>
 					<li class="st-li-progress">
 						<small class="st-progress-small">
-							<?php echo esc_html( $progress_item['created_at'] ); ?>
+								<?php echo esc_html( $stolmc_progress_item['created_at'] ); ?>
 						</small>
 
 						<div class="st-text-container">
 							<p>
-								<?php echo esc_html( $progress_item['text'] ); ?>
+									<?php echo esc_html( $stolmc_progress_item['text'] ); ?>
 							</p>
 						</div>
 					</li>

--- a/includes/STOLMC_Service_Tracker.php
+++ b/includes/STOLMC_Service_Tracker.php
@@ -1,6 +1,8 @@
 <?php
 namespace STOLMC_Service_Tracker\includes;
 
+defined( 'ABSPATH' ) || exit;
+
 use STOLMC_Service_Tracker\admin\STOLMC_Service_Tracker_Admin;
 use STOLMC_Service_Tracker\includes\Analytics\Analytics_Logger;
 use STOLMC_Service_Tracker\includes\Analytics\Analytics_Hooks;
@@ -214,6 +216,7 @@ class STOLMC_Service_Tracker {
 	 * @return void
 	 */
 	public function register_customer_role(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core WordPress hook name.
 		if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {
 			return;
 		}

--- a/includes/Utils/STOLMC_Service_Tracker_Loader.php
+++ b/includes/Utils/STOLMC_Service_Tracker_Loader.php
@@ -1,6 +1,8 @@
 <?php
 namespace STOLMC_Service_Tracker\includes\Utils;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Register all actions and filters for the plugin
  *

--- a/includes/Utils/STOLMC_Service_Tracker_Sql.php
+++ b/includes/Utils/STOLMC_Service_Tracker_Sql.php
@@ -287,7 +287,7 @@ class STOLMC_Service_Tracker_Sql {
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table, columns and order clause are validated.
 		$sql = 'SELECT ' . $column_sql . ' FROM ' . $table . $this->normalize_order_by_clause( $order_by );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query is built from validated SQL identifiers.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Query is built from validated SQL identifiers.
 		return $wpdb->get_results( $sql );
 	}
 
@@ -360,7 +360,7 @@ class STOLMC_Service_Tracker_Sql {
 
 		$sql .= $this->normalize_order_by_clause( $order_by );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic query with optional ORDER BY.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Dynamic query with optional ORDER BY.
 		return $wpdb->get_results( $sql );
 	}
 
@@ -451,7 +451,7 @@ class STOLMC_Service_Tracker_Sql {
 			$sql = $wpdb->prepare( $sql, ...$params );
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic query built above and prepared when params exist.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Dynamic query built above and prepared when params exist.
 		$results = $wpdb->get_results( $sql );
 
 		/**
@@ -514,7 +514,7 @@ class STOLMC_Service_Tracker_Sql {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Placeholder count is built from the same parameter list.
 		$sql = $wpdb->prepare( $sql, ...$params );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Query prepared above.
 		return (int) $wpdb->get_var( $sql );
 	}
 
@@ -534,7 +534,7 @@ class STOLMC_Service_Tracker_Sql {
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table reference validated.
 		$sql = 'SELECT COUNT(*) FROM ' . $table;
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- No dynamic values beyond validated table name.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- No dynamic values beyond validated table name.
 		return (int) $wpdb->get_var( $sql );
 	}
 
@@ -569,7 +569,7 @@ class STOLMC_Service_Tracker_Sql {
 			$sql = $wpdb->prepare( $sql, ...$where_parts['params'] );
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared when params exist.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Prepared when params exist.
 		return (int) $wpdb->get_var( $sql );
 	}
 
@@ -604,7 +604,7 @@ class STOLMC_Service_Tracker_Sql {
 			$sql = $wpdb->prepare( $sql, ...$where_parts['params'] );
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared when params exist.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Prepared when params exist.
 		$value = $wpdb->get_var( $sql );
 		if ( null === $value || '' === $value ) {
 			return null;
@@ -646,7 +646,7 @@ class STOLMC_Service_Tracker_Sql {
 			$sql = $wpdb->prepare( $sql, ...$where_parts['params'] );
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Prepared when params exist.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Prepared when params exist.
 		$results = $wpdb->get_col( $sql );
 		if ( ! is_array( $results ) ) {
 			return [];
@@ -689,7 +689,7 @@ class STOLMC_Service_Tracker_Sql {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Placeholder count is built from same params list.
 		$sql = $wpdb->prepare( $sql, ...$params );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Query prepared above.
 		$results = $wpdb->get_results( $sql, ARRAY_A );
 
 		return \is_array( $results ) ? $results : [];
@@ -754,7 +754,7 @@ class STOLMC_Service_Tracker_Sql {
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Placeholder count is built from the same parameter list.
 		$sql = $wpdb->prepare( $sql, ...$params );
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Query prepared above.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Query prepared above.
 		return $wpdb->get_results( $sql );
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,13 @@
 Contributors: rdelbem
 Tags: service, tracking, woocommerce
 Requires at least: 6.0
-Tested up to: 6.9.4
-Stable tag: 1.0.1
-Requires PHP: 8.0
+Tested up to: 6.9
+Stable tag: 2.0.0
+Requires PHP: 8.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Track client service progress with cases, status updates, analytics, and calendar insights.
 
 == Description ==
 


### PR DESCRIPTION
Addressing these comments from Plugin Check (PCP):

| File | Line | Column | Type | Code | Message |
|------|------|--------|------|------|---------|
| admin/translation/texts_array.php | 14 | 69 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| admin/translation/texts_array.php | 15 | 95 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| admin/translation/texts_array.php | 16 | 58 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| ... | ... | ... | ... | ... | ... |
| admin/partials/admin_page_bad_config.php | 6 | 142 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| includes/Application/STOLMC_Service_Tracker_Toggle_Service.php | 234 | 42 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| includes/Application/STOLMC_Service_Tracker_Toggle_Service.php | 235 | 35 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| includes/STOLMC_Service_Tracker.php | 230 | 51 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| includes/Controller_API/STOLMC_Service_Tracker_Api.php | 47 | 76 | ERROR | WordPress.WP.I18n.TextDomainMismatch | Mismatched text domain. Expected 'service-tracker-stable' but got 'service-tracker-stolmc'. |
| composer.json | 0 | 0 | WARNING | missing_composer_json_file | The "/vendor" directory exists but composer.json is missing. |
| Service_Tracker_init.php | 0 | 0 | ERROR | plugin_header_no_license | Missing "License" in Plugin Header. |
| Service_Tracker_init.php | 0 | 0 | WARNING | textdomain_mismatch | Text Domain mismatch. |
| Service_Tracker_init.php | 0 | 0 | WARNING | plugin_header_invalid_domain_path | Domain Path must start with "/". |
| includes/DTO/STOLMC_Service_Tracker_Case_Create_Dto.php | 60 | 75 | ERROR | WordPress.Security.EscapeOutput.ExceptionNotEscaped | Output not escaped ($field_name). |
| includes/DTO/STOLMC_Service_Tracker_Case_Update_Dto.php | 67 | 75 | ERROR | WordPress.Security.EscapeOutput.ExceptionNotEscaped | Output not escaped ($field). |
| includes/Application/STOLMC_Service_Tracker_Progress_Service.php | 663 | 10 | ERROR | Generic.PHP.ForbiddenFunctions.Found | move_uploaded_file() is forbidden. |
| includes/I18n/STOLMC_Service_Tracker_I18n.php | 39 | 3 | WARNING | discouraged_function | load_plugin_textdomain() discouraged. |
| readme.txt | 0 | 0 | ERROR | invalid_tested_upto_minor | Version should be major only (6.9). |
| readme.txt | 0 | 0 | ERROR | stable_tag_mismatch | Stable Tag mismatch. |
| admin/STOLMC_Service_Tracker_Admin.php | 0 | 0 | ERROR | missing_direct_file_access_protection | Missing ABSPATH check. |
| includes/Utils/STOLMC_Service_Tracker_Sql.php | 291 | 17 | WARNING | unescaped_db_parameter | Unsafe SQL usage. |
| includes/DB/Schema_Manager.php | 126 | 11 | WARNING | unescaped_db_parameter | Unsafe DB query. |